### PR TITLE
feat: add current conditions, smoke outlook, and fire weather summaries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,8 @@ OPENAI_API_KEY=your-openai-api-key-here
 
 # For Anthropic provider (if using LLM_PROVIDER=anthropic)
 # ANTHROPIC_API_KEY=your-anthropic-api-key-here
+
+# lfpweather-api: source for live station data and the fire danger summary used
+# by the current conditions, smoke outlook, and fire weather summaries.
+# LFPWEATHER_API_BASE_URL=https://your-lfpweather-api-host
+# LFPWEATHER_API_KEY=your-lfpweather-api-key-here

--- a/cmd/lfpweather-forecast-inference-api/main.go
+++ b/cmd/lfpweather-forecast-inference-api/main.go
@@ -11,7 +11,9 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/michaelpeterswa/lfpweather-forecast-inference-api/internal/config"
 	"github.com/michaelpeterswa/lfpweather-forecast-inference-api/internal/dragonfly"
+	"github.com/michaelpeterswa/lfpweather-forecast-inference-api/internal/generate"
 	"github.com/michaelpeterswa/lfpweather-forecast-inference-api/internal/handlers"
+	"github.com/michaelpeterswa/lfpweather-forecast-inference-api/internal/lfpweather"
 	"github.com/michaelpeterswa/lfpweather-forecast-inference-api/internal/llm"
 	"github.com/michaelpeterswa/lfpweather-forecast-inference-api/internal/logging"
 	"github.com/michaelpeterswa/lfpweather-forecast-inference-api/internal/middleware"
@@ -97,7 +99,22 @@ func main() {
 		os.Exit(1)
 	}
 
-	llmHandler := handlers.NewLLMHandler(llmProvider, nwsClient, dragonflyClient, c.LLMHandlerTimeout)
+	lfpweatherClient := lfpweather.NewClient(
+		&http.Client{Timeout: c.LFPWeatherClientTimeout},
+		c.LFPWeatherAPIBaseURL,
+		c.LFPWeatherAPIKey,
+	)
+
+	summaryGenerator := generate.New(
+		llmProvider,
+		lfpweatherClient,
+		nwsClient,
+		dragonflyClient,
+		c.GridPoint,
+		c.WorkerTimeout,
+	)
+
+	llmHandler := handlers.NewLLMHandler(llmProvider, nwsClient, dragonflyClient, summaryGenerator, c.LLMHandlerTimeout)
 
 	// Start background worker if enabled
 	if c.WorkerEnabled {
@@ -105,6 +122,7 @@ func main() {
 			llmProvider,
 			nwsClient,
 			dragonflyClient,
+			summaryGenerator,
 			c.WorkerInterval,
 			c.WorkerTimeout,
 			c.GridPoint,
@@ -119,6 +137,11 @@ func main() {
 
 	forecastSubrouter.HandleFunc("/summary", llmHandler.GetForecastSummary).Methods(http.MethodGet)
 	forecastSubrouter.HandleFunc("/detailed", llmHandler.GetForcastPeriodsInformation).Methods(http.MethodGet)
+
+	// Headline summaries that combine live station data with the forecast.
+	v1Subrouter.HandleFunc("/current", llmHandler.GetCurrentConditions).Methods(http.MethodGet)
+	v1Subrouter.HandleFunc("/smoke", llmHandler.GetSmokeOutlook).Methods(http.MethodGet)
+	v1Subrouter.HandleFunc("/fire_weather", llmHandler.GetFireWeather).Methods(http.MethodGet)
 
 	if c.AuthenticationEnabled {
 		authenticationMiddleware := middleware.NewAuthenticationMiddlewareClient(

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,8 +20,8 @@ type Config struct {
 	// OpenAI-compatible configuration
 	OpenAIAPIKey  string `env:"OPENAI_API_KEY"`
 	OpenAIModel   string `env:"OPENAI_MODEL" envDefault:"gpt-4o"`
-	OpenAIBaseURL string `env:"OPENAI_BASE_URL"`   // Optional: for OpenAI-compatible APIs (e.g., local LLMs, Azure)
-	OpenAINoThink bool   `env:"OPENAI_NO_THINK"`   // Optional: append /no_think to prompts (for Qwen 3 models)
+	OpenAIBaseURL string `env:"OPENAI_BASE_URL"` // Optional: for OpenAI-compatible APIs (e.g., local LLMs, Azure)
+	OpenAINoThink bool   `env:"OPENAI_NO_THINK"` // Optional: append /no_think to prompts (for Qwen 3 models)
 
 	// Handler timeout (applies to all providers)
 	LLMHandlerTimeout time.Duration `env:"LLM_HANDLER_TIMEOUT" envDefault:"10s"`
@@ -33,6 +33,13 @@ type Config struct {
 	GridPoint      string        `env:"GRID_POINT" envDefault:"SEW/127,75"`
 
 	NWSClientTimeout time.Duration `env:"NWS_CLIENT_TIMEOUT" envDefault:"5s"`
+
+	// lfpweather-api: source for live station observations and the fire danger
+	// summary, used by the current conditions, smoke outlook, and fire weather
+	// summaries.
+	LFPWeatherAPIBaseURL    string        `env:"LFPWEATHER_API_BASE_URL"`
+	LFPWeatherAPIKey        string        `env:"LFPWEATHER_API_KEY"`
+	LFPWeatherClientTimeout time.Duration `env:"LFPWEATHER_CLIENT_TIMEOUT" envDefault:"5s"`
 
 	AuthenticationEnabled bool     `env:"AUTHENTICATION_ENABLED" envDefault:"false"`
 	APIKeys               []string `env:"API_KEYS" envSeparator:","`

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -1,0 +1,256 @@
+// Package generate builds the headline summaries that combine live station
+// data from the lfpweather-api with the NWS forecast: current conditions, a
+// smoke outlook, and a fire weather read. Both the HTTP handlers and the
+// background worker use it, so the prompts and cache logic live in one place.
+package generate
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/michaelpeterswa/lfpweather-forecast-inference-api/internal/dragonfly"
+	"github.com/michaelpeterswa/lfpweather-forecast-inference-api/internal/lfpweather"
+	"github.com/michaelpeterswa/lfpweather-forecast-inference-api/internal/llm"
+	"github.com/michaelpeterswa/lfpweather-forecast-inference-api/internal/nws"
+	"github.com/redis/go-redis/v9"
+)
+
+// Cache key suffixes for each generated summary. The Dragonfly key prefix is
+// prepended at write time.
+const (
+	KeyCurrentConditions = "current-conditions"
+	KeySmokeOutlook      = "smoke-outlook"
+	KeyFireWeather       = "fire-weather"
+)
+
+// iconList is the shared icon vocabulary. Every summary picks one icon from
+// this set so the frontend can render it the same way as the forecast summary.
+const iconList = `cloud
+cloud-drizzle
+cloud-fog
+cloud-hail
+cloud-lightning
+cloud-moon
+cloud-moon-rain
+cloud-rain
+cloud-rain-wind
+cloud-snow
+cloud-sun
+cloud-sun-rain
+cloudy
+snowflake
+sun
+sun-snow
+thermometer-snowflake
+thermometer-sun
+wind`
+
+// Result is the cached payload and the HTTP response body for a summary. It
+// matches the {summary, icon, last_updated} shape of the forecast summary.
+type Result struct {
+	Summary     string    `json:"summary"`
+	Icon        string    `json:"icon"`
+	LastUpdated time.Time `json:"last_updated"`
+}
+
+// Generator produces the summaries and caches them in Dragonfly.
+type Generator struct {
+	llm       llm.Provider
+	lfp       *lfpweather.Client
+	nws       *nws.NWSClient
+	dragonfly *dragonfly.DragonflyClient
+	gridPoint string
+	timeout   time.Duration
+}
+
+// New returns a Generator. The timeout bounds each summary during a worker
+// refresh; the HTTP handlers pass their own request context.
+func New(
+	provider llm.Provider,
+	lfp *lfpweather.Client,
+	nwsClient *nws.NWSClient,
+	dragonflyClient *dragonfly.DragonflyClient,
+	gridPoint string,
+	timeout time.Duration,
+) *Generator {
+	return &Generator{
+		llm:       provider,
+		lfp:       lfp,
+		nws:       nwsClient,
+		dragonfly: dragonflyClient,
+		gridPoint: gridPoint,
+		timeout:   timeout,
+	}
+}
+
+// buildFunc fetches the inputs and produces a summary. It does not set
+// LastUpdated or touch the cache; produce does that.
+type buildFunc func(ctx context.Context) (*Result, error)
+
+// GetCurrentConditions returns the cached current conditions summary, or
+// generates and caches it on a miss.
+func (g *Generator) GetCurrentConditions(ctx context.Context) (*Result, error) {
+	return g.getOrProduce(ctx, KeyCurrentConditions, g.buildCurrentConditions)
+}
+
+// GetSmokeOutlook returns the cached smoke outlook, or generates and caches it
+// on a miss.
+func (g *Generator) GetSmokeOutlook(ctx context.Context) (*Result, error) {
+	return g.getOrProduce(ctx, KeySmokeOutlook, g.buildSmokeOutlook)
+}
+
+// GetFireWeather returns the cached fire weather summary, or generates and
+// caches it on a miss.
+func (g *Generator) GetFireWeather(ctx context.Context) (*Result, error) {
+	return g.getOrProduce(ctx, KeyFireWeather, g.buildFireWeather)
+}
+
+// RefreshAll regenerates and caches all three summaries at once. The
+// background worker calls it. Each summary runs with its own timeout, and a
+// failure in one does not stop the others.
+func (g *Generator) RefreshAll(ctx context.Context) {
+	jobs := []struct {
+		name  string
+		key   string
+		build buildFunc
+	}{
+		{"current conditions", KeyCurrentConditions, g.buildCurrentConditions},
+		{"smoke outlook", KeySmokeOutlook, g.buildSmokeOutlook},
+		{"fire weather", KeyFireWeather, g.buildFireWeather},
+	}
+
+	var wg sync.WaitGroup
+	for _, j := range jobs {
+		wg.Add(1)
+		go func(name, key string, build buildFunc) {
+			defer wg.Done()
+
+			jobCtx, cancel := context.WithTimeout(ctx, g.timeout)
+			defer cancel()
+
+			if _, err := g.produce(jobCtx, key, build); err != nil {
+				slog.Error("worker: failed to generate summary", slog.String("summary", name), slog.String("error", err.Error()))
+				return
+			}
+			slog.Info("worker: summary generated and cached", slog.String("summary", name))
+		}(j.name, j.key, j.build)
+	}
+	wg.Wait()
+}
+
+// cacheKey prepends the Dragonfly key prefix to a summary key.
+func (g *Generator) cacheKey(key string) string {
+	return fmt.Sprintf("%s-%s", g.dragonfly.KeyPrefix, key)
+}
+
+// getOrProduce returns the cached summary, or produces a fresh one on a miss.
+func (g *Generator) getOrProduce(ctx context.Context, key string, build buildFunc) (*Result, error) {
+	res, err := g.dragonfly.Client.Get(ctx, g.cacheKey(key)).Result()
+	if err != nil && err != redis.Nil {
+		slog.Error("could not read summary from cache", slog.String("key", key), slog.String("error", err.Error()))
+	} else if err == nil && res != "" {
+		var cached Result
+		if err := json.Unmarshal([]byte(res), &cached); err != nil {
+			slog.Error("could not unmarshal cached summary", slog.String("key", key), slog.String("error", err.Error()))
+		} else {
+			return &cached, nil
+		}
+	}
+
+	return g.produce(ctx, key, build)
+}
+
+// produce builds a summary, stamps it, caches it, and returns it.
+func (g *Generator) produce(ctx context.Context, key string, build buildFunc) (*Result, error) {
+	result, err := build(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result.LastUpdated = time.Now()
+
+	encoded, err := json.Marshal(result)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal summary: %w", err)
+	}
+
+	if err := g.dragonfly.Client.Set(ctx, g.cacheKey(key), encoded, g.dragonfly.CacheResultsDuration).Err(); err != nil {
+		slog.Error("could not cache summary", slog.String("key", key), slog.String("error", err.Error()))
+	}
+
+	return result, nil
+}
+
+// llmOutput is the JSON object each prompt asks the model to return.
+type llmOutput struct {
+	Summary string `json:"summary"`
+	Icon    string `json:"icon"`
+}
+
+// complete runs one prompt through the provider and parses the {summary, icon}
+// output.
+func (g *Generator) complete(ctx context.Context, systemPrompt, task string, shots []shot, input string) (*Result, error) {
+	response, err := g.llm.Complete(ctx, llm.CompletionRequest{
+		SystemPrompt: systemPrompt,
+		UserPrompt:   buildFinalPrompt(task, shots, input),
+		MaxTokens:    1024,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	cleaned := stripMarkdownCodeBlock(response.Content)
+
+	var out llmOutput
+	if err := json.Unmarshal([]byte(cleaned), &out); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal summary output: %w (raw: %s)", err, cleaned)
+	}
+
+	return &Result{Summary: out.Summary, Icon: out.Icon}, nil
+}
+
+// shot is one few-shot example.
+type shot struct {
+	Input  string
+	Output string
+}
+
+// multiShotWrapper renders few-shot examples as an <examples> block.
+func multiShotWrapper(shots []shot) string {
+	var sb strings.Builder
+	sb.WriteString("<examples>")
+	for _, s := range shots {
+		sb.WriteString("<example>")
+		sb.WriteString("input: ")
+		sb.WriteString(s.Input)
+		sb.WriteString("\noutput: ")
+		sb.WriteString(s.Output)
+		sb.WriteString("</example>")
+	}
+	sb.WriteString("</examples>")
+	return sb.String()
+}
+
+// buildFinalPrompt joins the task, the examples, and the input data.
+func buildFinalPrompt(task string, shots []shot, input string) string {
+	return fmt.Sprintf("%s\n\n%s\n\n%s", task, multiShotWrapper(shots), fmt.Sprintf("input: %s", input))
+}
+
+// stripMarkdownCodeBlock removes a leading ```json or ``` fence and a trailing
+// ``` fence so the JSON can be parsed.
+func stripMarkdownCodeBlock(text string) string {
+	text = strings.TrimSpace(text)
+	if strings.HasPrefix(text, "```json") {
+		text = strings.TrimPrefix(text, "```json")
+	} else if strings.HasPrefix(text, "```") {
+		text = strings.TrimPrefix(text, "```")
+	}
+	text = strings.TrimSpace(text)
+	text = strings.TrimSuffix(text, "```")
+	return strings.TrimSpace(text)
+}

--- a/internal/generate/generate_test.go
+++ b/internal/generate/generate_test.go
@@ -1,0 +1,40 @@
+package generate
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestStripMarkdownCodeBlock(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain json", `{"summary":"a","icon":"sun"}`, `{"summary":"a","icon":"sun"}`},
+		{"json fence", "```json\n{\"summary\":\"a\"}\n```", `{"summary":"a"}`},
+		{"bare fence", "```\n{\"summary\":\"a\"}\n```", `{"summary":"a"}`},
+		{"leading whitespace", "  \n{\"summary\":\"a\"}  ", `{"summary":"a"}`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := stripMarkdownCodeBlock(tc.in); got != tc.want {
+				t.Errorf("stripMarkdownCodeBlock(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildFinalPrompt(t *testing.T) {
+	shots := []shot{
+		{Input: `{"a":1}`, Output: `{"b":2}`},
+	}
+	got := buildFinalPrompt("do the thing", shots, `{"c":3}`)
+
+	for _, want := range []string{"do the thing", "<examples>", "<example>", `{"a":1}`, `{"b":2}`, "</examples>", `input: {"c":3}`} {
+		if !strings.Contains(got, want) {
+			t.Errorf("buildFinalPrompt output missing %q\ngot: %s", want, got)
+		}
+	}
+}

--- a/internal/generate/summaries.go
+++ b/internal/generate/summaries.go
@@ -1,0 +1,251 @@
+package generate
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// currentConditionsInput is the latest station reading, framed for the model.
+type currentConditionsInput struct {
+	TemperatureF      float64 `json:"temperature_f"`
+	HumidityPct       float64 `json:"relative_humidity_pct"`
+	WindSpeedMph      float64 `json:"wind_speed_mph"`
+	PressureInHg      float64 `json:"pressure_inhg"`
+	SolarRadiationWm2 float64 `json:"solar_radiation_wm2"`
+	UVIndex           float64 `json:"uv_index"`
+	Rain24hIn         float64 `json:"rain_last_24h_in"`
+	ObservedAt        string  `json:"observed_at"`
+}
+
+// buildCurrentConditions writes a short "right now" sentence from the latest
+// station observations.
+func (g *Generator) buildCurrentConditions(ctx context.Context) (*Result, error) {
+	temperature, err := g.lfp.TemperatureLast(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get temperature: %w", err)
+	}
+	humidity, err := g.lfp.HumidityLast(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get humidity: %w", err)
+	}
+	windSpeed, err := g.lfp.WindSpeedLast(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get wind speed: %w", err)
+	}
+	pressure, err := g.lfp.PressureLast(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get pressure: %w", err)
+	}
+	solar, err := g.lfp.SolarRadiationLast(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get solar radiation: %w", err)
+	}
+	uv, err := g.lfp.UVIndexLast(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get uv index: %w", err)
+	}
+	rain, err := g.lfp.RainLast24h(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get 24h rain: %w", err)
+	}
+
+	input := currentConditionsInput{
+		TemperatureF:      temperature.Last,
+		HumidityPct:       humidity.Last,
+		WindSpeedMph:      windSpeed.Last,
+		PressureInHg:      pressure.Last,
+		SolarRadiationWm2: solar.Last,
+		UVIndex:           uv.Last,
+		Rain24hIn:         rain.Last,
+		ObservedAt:        temperature.Time.Format("2006-01-02T15:04:05Z07:00"),
+	}
+
+	inputJSON, err := json.Marshal(input)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal current conditions input: %w", err)
+	}
+
+	systemPrompt := fmt.Sprintf(`You are a tool that describes the current weather at a backyard weather station near Seattle, Washington.
+You have access to the following list of icons:
+"""
+%s
+"""
+`, iconList)
+
+	task := `Input is a JSON object with the latest sensor readings from the station.
+Output is a JSON object with the key "summary" and the key "icon".
+"summary" is a single friendly sentence, or at most two, that describes the conditions right now.
+"icon" is the icon that best fits the current conditions.
+Report the temperature, and then the one or two other readings that stand out (for example strong wind, high humidity, recent rain, or strong sun).
+Use the solar radiation and the UV index to judge how sunny it is; a low solar radiation value means it is cloudy, dark, or night.
+Do not include any information that is not present in the input.
+Do not list every reading.
+Avoid editorializing or making assumptions.
+Make the output sound like a human wrote it, with concise but friendly language and complete sentences.`
+
+	shots := []shot{
+		{
+			Input:  `{"temperature_f":72.4,"relative_humidity_pct":41,"wind_speed_mph":8,"pressure_inhg":30.05,"solar_radiation_wm2":710,"uv_index":6,"rain_last_24h_in":0,"observed_at":"2024-07-14T14:20:00-07:00"}`,
+			Output: `{"summary": "It is a warm 72 degrees and sunny right now, with a light breeze and comfortable humidity.", "icon": "sun"}`,
+		},
+	}
+
+	return g.complete(ctx, systemPrompt, task, shots, string(inputJSON))
+}
+
+// smokeOutlookInput pairs the latest air quality reading with the near-term
+// NWS forecast text, which is where smoke and haze are called out.
+type smokeOutlookInput struct {
+	AQINow          float64          `json:"aqi_now"`
+	AQIObservedAt   string           `json:"aqi_observed_at"`
+	ForecastPeriods []forecastPeriod `json:"forecast_periods"`
+}
+
+// forecastPeriod is the part of an NWS period the smoke outlook needs.
+type forecastPeriod struct {
+	Name             string `json:"name"`
+	DetailedForecast string `json:"detailed_forecast"`
+}
+
+// buildSmokeOutlook grounds the "now" in the AirGradient AQI reading and uses
+// the NWS forecast text for the forward outlook.
+func (g *Generator) buildSmokeOutlook(ctx context.Context) (*Result, error) {
+	aqi, err := g.lfp.AQILast(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get aqi: %w", err)
+	}
+
+	periods, err := g.nws.GetSimplifiedForecastNPeriods(g.gridPoint, 4)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get forecast periods: %w", err)
+	}
+
+	input := smokeOutlookInput{
+		AQINow:        aqi.Last,
+		AQIObservedAt: aqi.Time.Format("2006-01-02T15:04:05Z07:00"),
+	}
+	for _, p := range periods {
+		input.ForecastPeriods = append(input.ForecastPeriods, forecastPeriod{
+			Name:             p.Name,
+			DetailedForecast: p.DetailedForecast,
+		})
+	}
+
+	inputJSON, err := json.Marshal(input)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal smoke outlook input: %w", err)
+	}
+
+	systemPrompt := fmt.Sprintf(`You are a tool that describes the wildfire smoke and air quality outlook near Seattle, Washington.
+You have access to the following list of icons:
+"""
+%s
+"""
+`, iconList)
+
+	task := `Input is a JSON object.
+"aqi_now" is the current air quality index from a local sensor. Lower is cleaner: 0 to 50 is good, 51 to 100 is moderate, 101 to 150 is unhealthy for sensitive groups, and above 150 is unhealthy.
+"forecast_periods" is the near-term NWS forecast text, where smoke and haze are called out.
+Output is a JSON object with the key "summary" and the key "icon".
+"summary" is a single sentence, or at most two, that describes the air quality now and whether smoke or haze is expected to build or clear.
+Use "aqi_now" to describe the air right now.
+Read the forecast text for words like smoke, haze, or wildfire to describe the outlook.
+If the air is clean now and the forecast does not mention smoke, say the air is clear and no smoke is expected.
+"icon" is "cloud-fog" when the air is smoky or hazy, and "sun" when the air is clear.
+Do not include any information that is not present in the input.
+Do not give health advice.
+Avoid editorializing or making assumptions.
+Make the output sound like a human wrote it, with concise but friendly language and complete sentences.`
+
+	shots := []shot{
+		{
+			Input:  `{"aqi_now":18,"aqi_observed_at":"2024-08-02T10:00:00-07:00","forecast_periods":[{"name":"Today","detailed_forecast":"Sunny, with a high near 82. Light west wind."}]}`,
+			Output: `{"summary": "Air quality is good right now with an AQI of 18, and no smoke is expected today.", "icon": "sun"}`,
+		},
+		{
+			Input:  `{"aqi_now":126,"aqi_observed_at":"2024-08-20T13:00:00-07:00","forecast_periods":[{"name":"This Afternoon","detailed_forecast":"Areas of smoke after 2pm. Sunny and hazy, with a high near 90."}]}`,
+			Output: `{"summary": "Air quality is unhealthy for sensitive groups at an AQI of 126, and areas of smoke are expected to move in this afternoon.", "icon": "cloud-fog"}`,
+		},
+	}
+
+	return g.complete(ctx, systemPrompt, task, shots, string(inputJSON))
+}
+
+// fireWeatherInput is the part of the fire danger summary the read needs.
+type fireWeatherInput struct {
+	Class         string  `json:"danger_class"`
+	Headline      string  `json:"headline"`
+	ERCValue      float64 `json:"erc_value"`
+	ERCPercentile float64 `json:"erc_percentile"`
+	BurningIndex  float64 `json:"burning_index"`
+	KBDI          float64 `json:"kbdi_drought_0_to_800"`
+	GSI           float64 `json:"greenup_0_to_1"`
+	Dead10hrPct   float64 `json:"dead_10hr_moisture_pct"`
+	Dead100hrPct  float64 `json:"dead_100hr_moisture_pct"`
+	LiveHerbPct   float64 `json:"live_herbaceous_moisture_pct"`
+	ObservedAt    string  `json:"observed_at"`
+}
+
+// buildFireWeather writes a plain-language read of today's fire danger from the
+// lfpweather-api fire danger summary.
+func (g *Generator) buildFireWeather(ctx context.Context) (*Result, error) {
+	summary, err := g.lfp.FireDangerSummary(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get fire danger summary: %w", err)
+	}
+
+	input := fireWeatherInput{
+		Class:         summary.Rating.Class,
+		Headline:      summary.Rating.Headline,
+		ERCValue:      summary.EnergyRelease.Value,
+		ERCPercentile: summary.EnergyRelease.Percentile,
+		BurningIndex:  summary.BurningIndex.Value,
+		KBDI:          summary.Drought.KBDI,
+		GSI:           summary.Drought.GSI,
+		Dead10hrPct:   summary.FuelMoisture.Dead10hr,
+		Dead100hrPct:  summary.FuelMoisture.Dead100hr,
+		LiveHerbPct:   summary.FuelMoisture.LiveHerb,
+		ObservedAt:    summary.Time.Format("2006-01-02T15:04:05Z07:00"),
+	}
+
+	inputJSON, err := json.Marshal(input)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal fire weather input: %w", err)
+	}
+
+	systemPrompt := fmt.Sprintf(`You are a tool that describes today's fire weather near Seattle, Washington for a general audience.
+You have access to the following list of icons:
+"""
+%s
+"""
+`, iconList)
+
+	task := `Input is a JSON object with today's fire danger for the station.
+"danger_class" is the danger rating, such as Low, Moderate, High, Very High, or Extreme.
+"erc_percentile" ranks today's energy release component against the season, from 0 to 1; a high percentile means the fuels hold more energy than usual for this time of year.
+"kbdi_drought_0_to_800" is a drought index; a higher value means drier soil.
+"greenup_0_to_1" describes live plant growth; a value near 1 means the plants are green.
+The moisture values are the water content of dead and live fuels, in percent; lower values mean drier fuels.
+Output is a JSON object with the key "summary" and the key "icon".
+"summary" is a single sentence, or at most two, that states the danger class and the one or two conditions that drive it, such as dry fuels, drought, or green plant growth.
+Say whether today is high or low for the season, using the percentile.
+"icon" is "thermometer-sun" when the danger is High or above, and "sun" when the danger is Moderate or below.
+Do not include any information that is not present in the input.
+Do not give safety instructions.
+Avoid jargon and avoid editorializing.
+Make the output sound like a human wrote it, with concise but friendly language and complete sentences.`
+
+	shots := []shot{
+		{
+			Input:  `{"danger_class":"Low","headline":"Low fire danger","erc_value":12,"erc_percentile":0.22,"burning_index":8,"kbdi_drought_0_to_800":90,"greenup_0_to_1":0.85,"dead_10hr_moisture_pct":18,"dead_100hr_moisture_pct":22,"live_herbaceous_moisture_pct":140,"observed_at":"2024-05-10T13:00:00-07:00"}`,
+			Output: `{"summary": "Fire danger is low today, which is typical for this time of year, with damp fuels and green plant growth keeping conditions mild.", "icon": "sun"}`,
+		},
+		{
+			Input:  `{"danger_class":"Very High","headline":"Very high fire danger","erc_value":58,"erc_percentile":0.95,"burning_index":72,"kbdi_drought_0_to_800":540,"greenup_0_to_1":0.2,"dead_10hr_moisture_pct":6,"dead_100hr_moisture_pct":8,"live_herbaceous_moisture_pct":45,"observed_at":"2024-08-18T13:00:00-07:00"}`,
+			Output: `{"summary": "Fire danger is very high today and near the top of the range for the season, driven by very dry fuels and deep drought.", "icon": "thermometer-sun"}`,
+		},
+	}
+
+	return g.complete(ctx, systemPrompt, task, shots, string(inputJSON))
+}

--- a/internal/handlers/llm.go
+++ b/internal/handlers/llm.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/michaelpeterswa/lfpweather-forecast-inference-api/internal/dragonfly"
+	"github.com/michaelpeterswa/lfpweather-forecast-inference-api/internal/generate"
 	"github.com/michaelpeterswa/lfpweather-forecast-inference-api/internal/llm"
 	"github.com/michaelpeterswa/lfpweather-forecast-inference-api/internal/nws"
 )
@@ -12,14 +13,16 @@ type LLMHandler struct {
 	LLMProvider     llm.Provider
 	NWSClient       *nws.NWSClient
 	DragonflyClient *dragonfly.DragonflyClient
+	Generator       *generate.Generator
 	Timeout         time.Duration
 }
 
-func NewLLMHandler(provider llm.Provider, nc *nws.NWSClient, dc *dragonfly.DragonflyClient, timeout time.Duration) *LLMHandler {
+func NewLLMHandler(provider llm.Provider, nc *nws.NWSClient, dc *dragonfly.DragonflyClient, generator *generate.Generator, timeout time.Duration) *LLMHandler {
 	return &LLMHandler{
 		LLMProvider:     provider,
 		NWSClient:       nc,
 		DragonflyClient: dc,
+		Generator:       generator,
 		Timeout:         timeout,
 	}
 }

--- a/internal/handlers/summaries.go
+++ b/internal/handlers/summaries.go
@@ -1,0 +1,65 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"alpineworks.io/rfc9457"
+	"github.com/michaelpeterswa/lfpweather-forecast-inference-api/internal/generate"
+)
+
+// GetCurrentConditions serves GET /api/v1/current: a point-in-time summary of
+// the latest station observations.
+func (lh *LLMHandler) GetCurrentConditions(w http.ResponseWriter, r *http.Request) {
+	lh.serveSummary(w, r, "current conditions", lh.Generator.GetCurrentConditions)
+}
+
+// GetSmokeOutlook serves GET /api/v1/smoke: the air quality and wildfire smoke
+// outlook.
+func (lh *LLMHandler) GetSmokeOutlook(w http.ResponseWriter, r *http.Request) {
+	lh.serveSummary(w, r, "smoke outlook", lh.Generator.GetSmokeOutlook)
+}
+
+// GetFireWeather serves GET /api/v1/fire_weather: a plain-language read of
+// today's fire danger.
+func (lh *LLMHandler) GetFireWeather(w http.ResponseWriter, r *http.Request) {
+	lh.serveSummary(w, r, "fire weather", lh.Generator.GetFireWeather)
+}
+
+// serveSummary runs a generator, writes the JSON result, and returns an RFC
+// 9457 problem on error.
+func (lh *LLMHandler) serveSummary(w http.ResponseWriter, r *http.Request, name string, fn func(context.Context) (*generate.Result, error)) {
+	timeoutCtx, cancel := context.WithTimeout(r.Context(), lh.Timeout)
+	defer cancel()
+
+	result, err := fn(timeoutCtx)
+	if err != nil {
+		slog.Error("failed to get summary", slog.String("summary", name), slog.String("error", err.Error()))
+		rfc9457.NewRFC9457(
+			rfc9457.WithTitle(fmt.Sprintf("failed to get %s summary", name)),
+			rfc9457.WithDetail(fmt.Sprintf("failed to get %s summary: %s", name, err.Error())),
+			rfc9457.WithInstance(r.URL.Path),
+			rfc9457.WithStatus(http.StatusInternalServerError),
+		).ServeHTTP(w, r)
+		return
+	}
+
+	resultJSON, err := json.Marshal(result)
+	if err != nil {
+		slog.Error("failed to marshal summary", slog.String("summary", name), slog.String("error", err.Error()))
+		rfc9457.NewRFC9457(
+			rfc9457.WithTitle(fmt.Sprintf("failed to marshal %s summary", name)),
+			rfc9457.WithDetail(fmt.Sprintf("failed to marshal %s summary: %s", name, err.Error())),
+			rfc9457.WithInstance(r.URL.Path),
+			rfc9457.WithStatus(http.StatusInternalServerError),
+		).ServeHTTP(w, r)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(resultJSON)
+}

--- a/internal/lfpweather/lfpweather.go
+++ b/internal/lfpweather/lfpweather.go
@@ -1,0 +1,163 @@
+// Package lfpweather is a small client for the lfpweather-api. The inference
+// API uses it to read the latest station observations and the fire danger
+// summary, which feed the current conditions, smoke outlook, and fire weather
+// summaries.
+package lfpweather
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Client calls the lfpweather-api. It sends the configured API key in the
+// X-API-Key header on every request.
+type Client struct {
+	httpClient *http.Client
+	baseURL    string
+	apiKey     string
+}
+
+// NewClient returns a Client for the lfpweather-api at baseURL. A trailing
+// slash on baseURL is removed. The apiKey may be empty when the target does
+// not require authentication.
+func NewClient(httpClient *http.Client, baseURL, apiKey string) *Client {
+	return &Client{
+		httpClient: httpClient,
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		apiKey:     apiKey,
+	}
+}
+
+// LastReading is the {time, last} shape that every lfpweather-api "/last"
+// endpoint returns.
+type LastReading struct {
+	Time time.Time `json:"time"`
+	Last float64   `json:"last"`
+}
+
+// FireDangerSummary is the subset of the lfpweather-api fire danger summary
+// that the fire weather generator needs. The full response has more fields;
+// this client decodes only the ones it uses.
+type FireDangerSummary struct {
+	Time      time.Time `json:"time"`
+	FuelModel string    `json:"fuel_model"`
+	Rating    struct {
+		Class    string `json:"class"`
+		Level    int    `json:"level"`
+		Headline string `json:"headline"`
+		Detail   string `json:"detail"`
+	} `json:"rating"`
+	EnergyRelease struct {
+		Value      float64 `json:"value"`
+		Percentile float64 `json:"percentile"`
+		P50        float64 `json:"p50"`
+		P80        float64 `json:"p80"`
+		P90        float64 `json:"p90"`
+		P97        float64 `json:"p97"`
+	} `json:"energy_release"`
+	BurningIndex struct {
+		Value float64 `json:"value"`
+	} `json:"burning_index"`
+	Drought struct {
+		KBDI float64 `json:"kbdi"`
+		GSI  float64 `json:"gsi"`
+	} `json:"drought"`
+	FuelMoisture struct {
+		Dead1hr   float64 `json:"dead_1hr"`
+		Dead10hr  float64 `json:"dead_10hr"`
+		Dead100hr float64 `json:"dead_100hr"`
+		LiveHerb  float64 `json:"live_herbaceous"`
+		LiveWoody float64 `json:"live_woody"`
+	} `json:"fuel_moisture"`
+}
+
+// get performs an authenticated GET and decodes the JSON body into out.
+func (c *Client) get(ctx context.Context, path string, out any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
+	if err != nil {
+		return fmt.Errorf("failed to build request for %s: %w", path, err)
+	}
+	if c.apiKey != "" {
+		req.Header.Set("X-API-Key", c.apiKey)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to get %s: %w", path, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status %d from %s", resp.StatusCode, path)
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		return fmt.Errorf("failed to decode %s: %w", path, err)
+	}
+	return nil
+}
+
+// getLast reads a single {time, last} endpoint.
+func (c *Client) getLast(ctx context.Context, path string) (LastReading, error) {
+	var lr LastReading
+	if err := c.get(ctx, path, &lr); err != nil {
+		return LastReading{}, err
+	}
+	return lr, nil
+}
+
+// TemperatureLast returns the latest temperature reading in degrees Fahrenheit.
+func (c *Client) TemperatureLast(ctx context.Context) (LastReading, error) {
+	return c.getLast(ctx, "/api/v1/temperature/last")
+}
+
+// HumidityLast returns the latest relative humidity reading in percent.
+func (c *Client) HumidityLast(ctx context.Context) (LastReading, error) {
+	return c.getLast(ctx, "/api/v1/humidity/last")
+}
+
+// PressureLast returns the latest barometric pressure reading in inches of
+// mercury.
+func (c *Client) PressureLast(ctx context.Context) (LastReading, error) {
+	return c.getLast(ctx, "/api/v1/pressure/last")
+}
+
+// WindSpeedLast returns the latest wind speed reading in miles per hour.
+func (c *Client) WindSpeedLast(ctx context.Context) (LastReading, error) {
+	return c.getLast(ctx, "/api/v1/wind_speed/last")
+}
+
+// SolarRadiationLast returns the latest solar radiation reading in watts per
+// square meter.
+func (c *Client) SolarRadiationLast(ctx context.Context) (LastReading, error) {
+	return c.getLast(ctx, "/api/v1/solar_radiation/last")
+}
+
+// UVIndexLast returns the latest UV index reading.
+func (c *Client) UVIndexLast(ctx context.Context) (LastReading, error) {
+	return c.getLast(ctx, "/api/v1/uv_index/last")
+}
+
+// RainLast24h returns the accumulated rainfall over the last 24 hours in
+// inches.
+func (c *Client) RainLast24h(ctx context.Context) (LastReading, error) {
+	return c.getLast(ctx, "/api/v1/24h_rain/last")
+}
+
+// AQILast returns the latest air quality index reading.
+func (c *Client) AQILast(ctx context.Context) (LastReading, error) {
+	return c.getLast(ctx, "/api/v1/aqi/last")
+}
+
+// FireDangerSummary returns the latest fire danger summary.
+func (c *Client) FireDangerSummary(ctx context.Context) (FireDangerSummary, error) {
+	var s FireDangerSummary
+	if err := c.get(ctx, "/api/v1/fire_danger/summary", &s); err != nil {
+		return FireDangerSummary{}, err
+	}
+	return s, nil
+}

--- a/internal/lfpweather/lfpweather_test.go
+++ b/internal/lfpweather/lfpweather_test.go
@@ -1,0 +1,113 @@
+package lfpweather
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestLastEndpoints(t *testing.T) {
+	cases := []struct {
+		name     string
+		wantPath string
+		call     func(*Client, context.Context) (LastReading, error)
+	}{
+		{"temperature", "/api/v1/temperature/last", (*Client).TemperatureLast},
+		{"humidity", "/api/v1/humidity/last", (*Client).HumidityLast},
+		{"pressure", "/api/v1/pressure/last", (*Client).PressureLast},
+		{"wind_speed", "/api/v1/wind_speed/last", (*Client).WindSpeedLast},
+		{"solar_radiation", "/api/v1/solar_radiation/last", (*Client).SolarRadiationLast},
+		{"uv_index", "/api/v1/uv_index/last", (*Client).UVIndexLast},
+		{"24h_rain", "/api/v1/24h_rain/last", (*Client).RainLast24h},
+		{"aqi", "/api/v1/aqi/last", (*Client).AQILast},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotPath, gotKey string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				gotKey = r.Header.Get("X-API-Key")
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"time":"2024-08-02T10:00:00Z","last":42.5}`))
+			}))
+			defer srv.Close()
+
+			client := NewClient(srv.Client(), srv.URL, "secret-key")
+			got, err := tc.call(client, context.Background())
+			if err != nil {
+				t.Fatalf("call returned error: %v", err)
+			}
+			if gotPath != tc.wantPath {
+				t.Errorf("path = %q, want %q", gotPath, tc.wantPath)
+			}
+			if gotKey != "secret-key" {
+				t.Errorf("X-API-Key = %q, want %q", gotKey, "secret-key")
+			}
+			if got.Last != 42.5 {
+				t.Errorf("Last = %v, want 42.5", got.Last)
+			}
+			if !got.Time.Equal(time.Date(2024, 8, 2, 10, 0, 0, 0, time.UTC)) {
+				t.Errorf("Time = %v, want 2024-08-02T10:00:00Z", got.Time)
+			}
+		})
+	}
+}
+
+func TestFireDangerSummary(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/fire_danger/summary" {
+			t.Errorf("path = %q, want /api/v1/fire_danger/summary", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"time":"2024-08-18T13:00:00Z",
+			"fuel_model":"G",
+			"rating":{"class":"Very High","level":4,"headline":"Very high fire danger","detail":"d"},
+			"energy_release":{"value":58,"percentile":0.95,"p50":30,"p80":45,"p90":52,"p97":60},
+			"burning_index":{"value":72},
+			"drought":{"kbdi":540,"gsi":0.2},
+			"fuel_moisture":{"dead_1hr":5,"dead_10hr":6,"dead_100hr":8,"live_herbaceous":45,"live_woody":80}
+		}`))
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.Client(), srv.URL, "")
+	got, err := client.FireDangerSummary(context.Background())
+	if err != nil {
+		t.Fatalf("FireDangerSummary returned error: %v", err)
+	}
+	if got.Rating.Class != "Very High" {
+		t.Errorf("Rating.Class = %q, want Very High", got.Rating.Class)
+	}
+	if got.EnergyRelease.Percentile != 0.95 {
+		t.Errorf("EnergyRelease.Percentile = %v, want 0.95", got.EnergyRelease.Percentile)
+	}
+	if got.Drought.KBDI != 540 {
+		t.Errorf("Drought.KBDI = %v, want 540", got.Drought.KBDI)
+	}
+	if got.FuelMoisture.Dead10hr != 6 {
+		t.Errorf("FuelMoisture.Dead10hr = %v, want 6", got.FuelMoisture.Dead10hr)
+	}
+}
+
+func TestGetNonOKStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.Client(), srv.URL, "")
+	if _, err := client.TemperatureLast(context.Background()); err == nil {
+		t.Fatal("expected error on non-200 status, got nil")
+	}
+}
+
+func TestNewClientTrimsTrailingSlash(t *testing.T) {
+	client := NewClient(http.DefaultClient, "https://example.com/", "k")
+	if client.baseURL != "https://example.com" {
+		t.Errorf("baseURL = %q, want https://example.com", client.baseURL)
+	}
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/michaelpeterswa/lfpweather-forecast-inference-api/internal/dragonfly"
+	"github.com/michaelpeterswa/lfpweather-forecast-inference-api/internal/generate"
 	"github.com/michaelpeterswa/lfpweather-forecast-inference-api/internal/llm"
 	"github.com/michaelpeterswa/lfpweather-forecast-inference-api/internal/nws"
 )
@@ -18,6 +19,7 @@ type ForecastWorker struct {
 	LLMProvider     llm.Provider
 	NWSClient       *nws.NWSClient
 	DragonflyClient *dragonfly.DragonflyClient
+	Generator       *generate.Generator
 	Interval        time.Duration
 	Timeout         time.Duration
 	GridPoint       string
@@ -28,6 +30,7 @@ func NewForecastWorker(
 	provider llm.Provider,
 	nwsClient *nws.NWSClient,
 	dragonflyClient *dragonfly.DragonflyClient,
+	generator *generate.Generator,
 	interval time.Duration,
 	timeout time.Duration,
 	gridPoint string,
@@ -36,6 +39,7 @@ func NewForecastWorker(
 		LLMProvider:     provider,
 		NWSClient:       nwsClient,
 		DragonflyClient: dragonflyClient,
+		Generator:       generator,
 		Interval:        interval,
 		Timeout:         timeout,
 		GridPoint:       gridPoint,
@@ -67,8 +71,8 @@ func (w *ForecastWorker) Start(ctx context.Context) {
 func (w *ForecastWorker) runGeneration(ctx context.Context) {
 	slog.Info("running forecast generation")
 
-	// Run both generations concurrently
-	done := make(chan struct{}, 2)
+	// Run all generations concurrently
+	done := make(chan struct{}, 3)
 
 	go func() {
 		w.generateForecastSummary(ctx)
@@ -80,7 +84,15 @@ func (w *ForecastWorker) runGeneration(ctx context.Context) {
 		done <- struct{}{}
 	}()
 
-	// Wait for both to complete
+	go func() {
+		// RefreshAll regenerates the current conditions, smoke outlook, and
+		// fire weather summaries.
+		w.Generator.RefreshAll(ctx)
+		done <- struct{}{}
+	}()
+
+	// Wait for all to complete
+	<-done
 	<-done
 	<-done
 


### PR DESCRIPTION
Adds three headline summaries that combine live station data from the lfpweather-api with the NWS forecast.

## New endpoints (each returns the existing `{summary, icon, last_updated}` shape)
- `GET /api/v1/current` — **current conditions**: a point-in-time read of the latest observations (temp, humidity, wind, pressure, solar, UV, 24h rain)
- `GET /api/v1/smoke` — **smoke outlook**: current AirGradient AQI grounds "now", NWS forecast text drives the forward outlook
- `GET /api/v1/fire_weather` — **fire weather**: a plain-language read of the fire danger summary (ERC percentile, KBDI, fuel moisture)

## How it works
- New `internal/lfpweather` HTTP client reads the `/last` endpoints and `/fire_danger/summary` (sends `X-API-Key`).
- New `internal/generate` package owns the prompts, few-shot examples, LLM call, and cache-aside for all three; the handlers and the background worker both use it (no prompt duplication).
- The worker pre-generates all three on its tick via `RefreshAll`; a failure in one does not stall the others.
- Reuses the existing provider-agnostic `llm.Provider` — no new SDK calls, model config untouched.

## Config
New env: `LFPWEATHER_API_BASE_URL`, `LFPWEATHER_API_KEY`, `LFPWEATHER_CLIENT_TIMEOUT` (see `.env.example`).

## Tests
- httptest coverage for every client method (path, `X-API-Key`, decoding, non-200)
- table-driven tests for the prompt/fence helpers

`go build`, `go vet`, `go test ./...`, `gofmt` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)